### PR TITLE
Update limit check section to fix splice error

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function hexo_generator_json_feed(site) {
       return post.published;
     });
 
-    if (config.limit) posts = posts.splice(0, config.limit);
+    if (config.limit) posts = posts.data.splice(0, config.limit);
 
     siteAuthor = {
 		name: hexo.config.author,


### PR DESCRIPTION
When running any of the Hexo commands that would generate a new feed, like hexo server or hexo generate, I get the following error:

> INFO  Start processing
> FATAL Something's wrong. Maybe you can find the solution ...
> TypeError: posts.splice is not a function

I was able to fix this by changing the following line from:

`if (config.limit) posts = posts.splice(0, config.limit);`

to

`if (config.limit) posts = posts.limit(config.limit);`